### PR TITLE
vfs: Fix counting in `inode_avail_count`

### DIFF
--- a/components/fs/vfs/src/vfs_inode.c
+++ b/components/fs/vfs/src/vfs_inode.c
@@ -131,7 +131,7 @@ int inode_avail_count(void)
     int e = 0;
 
     for (; e < AOS_CONFIG_VFS_DEV_NODES; e++) {
-        if (g_vfs_dev_nodes[count].type == VFS_TYPE_NOT_INIT) {
+        if (g_vfs_dev_nodes[e].type == VFS_TYPE_NOT_INIT) {
             count++;
         }
     }


### PR DESCRIPTION
As seen in `inode_del` and `inode_alloc`, a free (`VFS_TYPE_NOT_INIT`) node can be found anywhere in `g_vfs_dev_nodes`; it’s a “sparse” list.

So when checking for free nodes, the iterating index variable (`e`) shall be used, not the counter (`count`). The code got that wrong.

For instance, if the first node is not available (type is not `VFS_TYPE_NOT_INIT`), then the function previously returned 0, no matter what, and was iterating the node list in vain.