### PR TITLE
Add Quick Start to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,3 +6,23 @@ Bouffalolab bl_iot_sdk. Support BL602 Wi-Fi/BLE Combo RISC-V based Chip.
 Check ``docs/html`` for more detail.
 
 Fire an issue, if you have any issue or need any support.
+
+Quick Start
+===========
+
+In order to build one of the sample apps, you need to set a few environment
+variables:
+```
+export BL60X_SDK_PATH=/path/to/this/repo
+export CONFIG_CHIP_NAME=bl602
+```
+Then go to the sample directory of interest and call `make`, for example:
+```
+cd customer_app/bl602_boot2
+make
+```
+There is a linker script (written in python) at `image_conf/flash_build.py`.
+To run this, you need to specify the application and the target, for example:
+```
+python3 flash_build.py bl602_boot2 bl602
+```

--- a/image_conf/requirements.txt
+++ b/image_conf/requirements.txt
@@ -1,0 +1,2 @@
+fdt>=0.2.0
+pycryptodomex>=3.9.8


### PR DESCRIPTION
In lieu of the updates to `docs/html` currently in progress, it might make sense to have a simple `Quick Start` in the top-level README to reduce friction for new contributers.