### PR TITLE
Fix buffer overflow in EAP

### DIFF
--- a/components/network/lwip/src/netif/ppp/eap.c
+++ b/components/network/lwip/src/netif/ppp/eap.c
@@ -1417,7 +1417,7 @@ static void eap_request(ppp_pcb *pcb, u_char *inp, int id, int len) {
 		}
 
 		/* Not so likely to happen. */
-		if (vallen >= len + sizeof (rhostname)) {
+		if (len - vallen >= sizeof (rhostname)) {
 			ppp_dbglog("EAP: trimming really long peer name down");
 			MEMCPY(rhostname, inp + vallen, sizeof (rhostname) - 1);
 			rhostname[sizeof (rhostname) - 1] = '\0';
@@ -1845,7 +1845,7 @@ static void eap_response(ppp_pcb *pcb, u_char *inp, int id, int len) {
 		}
 
 		/* Not so likely to happen. */
-		if (vallen >= len + sizeof (rhostname)) {
+		if (len - vallen >= sizeof (rhostname)) {
 			ppp_dbglog("EAP: trimming really long peer name down");
 			MEMCPY(rhostname, inp + vallen, sizeof (rhostname) - 1);
 			rhostname[sizeof (rhostname) - 1] = '\0';


### PR DESCRIPTION
I discovered that in the source code, there is a shipped old version of pppd, which is vulnerable to [CVE-2020-8597](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8597). The change comes from this commit: https://github.com/paulusmack/ppp/commit/8d7970b8f3db727fe798b65f3377fe6787575426#diff-db4f879388d4749fc656d318c8d47e9256e5669ec217aebcf0f8bfb0aff46cfc

As I am sending it to forked repository, I would like to know if you will be sending changes done in this repository to the origin repository or I should do it.