### PR TITLE
Fix mismatched datatypes in DMA arguments.

### DIFF
--- a/components/bl602/bl602/evb/src/debug.c
+++ b/components/bl602/bl602/evb/src/debug.c
@@ -292,9 +292,8 @@ char *fcvtbuf(double arg, int ndigits, int *decpt, int *sign, char *buf)
   return cvt(arg, ndigits, decpt, sign, buf, 0);
 }
 
-static void ee_bufcpy(char *d, char *s, int count); 
- 
-void ee_bufcpy(char *pd, char *ps, int count) {
+#ifndef DISABLE_PRINT_FLOAT
+static void ee_bufcpy(char *pd, char *ps, int count) {
 	char *pe=ps+count;
 	while (ps!=pe)
 		*pd++=*ps++;
@@ -500,6 +499,7 @@ static char *flt(char *str, double num, int size, int precision, char fmt, int f
 
   return str;
 }
+#endif //  DISABLE_PRINT_FLOAT
 
 
 /*use O0 preventing consuming more stack*/

--- a/customer_app/bl602_boot2_mini/bl602_boot2_mini/blsp_boot2.c
+++ b/customer_app/bl602_boot2_mini/bl602_boot2_mini/blsp_boot2.c
@@ -171,6 +171,13 @@ static void BLSP_Boot2_On_Error(void *log)
     }
 }
 
+#if 0
+
+// This code is provenly unreachable (static, no callers in this translation
+// unit) but it may be inspirational for a GDB macro. OTOH, it's not much
+// more complicated than ' p ptEntry', though a convenience wrapper to print
+// the active index might be nice.
+
 /****************************************************************************//**
  * @brief  Boot2 Dump partition entry
  *
@@ -186,191 +193,7 @@ static void BLSP_Dump_PtEntry(PtTable_Entry_Config *ptEntry)
     MSG("active Index=%d\r\n",(unsigned int)ptEntry->activeIndex);
     MSG("active Address=%08x\r\n",(unsigned int)ptEntry->Address[ptEntry->activeIndex]);
 }
-
-/****************************************************************************//**
- * @brief  Boot2 check XZ FW and do decompression
- *
- * @param  activeID: Active partition table ID
- * @param  ptStuff: Pointer of partition table stuff
- * @param  ptEntry: Pointer of active entry
- *
- * @return 1 for find XZ FW and decompress success, 0 for other cases
- *
-*******************************************************************************/
-static int BLSP_Boot2_Check_XZ_FW(PtTable_ID_Type activeID,PtTable_Stuff_Config *ptStuff,PtTable_Entry_Config *ptEntry)
-{
-    uint8_t buf[6];
-
-    if(BFLB_BOOT2_SUCCESS!=BLSP_MediaBoot_Read(ptEntry->Address[ptEntry->activeIndex],buf,sizeof(buf))){
-        MSG_ERR("Read fw fail\r\n");
-        return 0;
-    }
-    if(BLSP_Boot2_Dump_Critical_Flag()){
-        BLSP_Dump_Data(buf,sizeof(buf));
-    }
-    if(BLSP_Boot2_Verify_XZ_Header(buf)==1){
-        MSG_DBG("XZ image\r\n");
-        if(BFLB_BOOT2_SUCCESS==BLSP_Boot2_Update_Fw(activeID,ptStuff,ptEntry)){
-            return 1;
-        }else{
-            MSG_ERR("Img decompress fail\r\n");
-            /* Set flag to make it not boot */
-            ptEntry->activeIndex=0;
-            ptEntry->Address[0]=0;
-            return 0;
-        }
-    }
-    return 0;
-}
-
-/****************************************************************************//**
- * @brief  Boot2 copy firmware from OTA region to normal region
- *
- * @param  activeID: Active partition table ID
- * @param  ptStuff: Pointer of partition table stuff
- * @param  ptEntry: Pointer of active entry
- *
- * @return BL_Err_Type
- *
-*******************************************************************************/
-static int BLSP_Boot2_Do_FW_Copy(PtTable_ID_Type activeID,PtTable_Stuff_Config *ptStuff,PtTable_Entry_Config *ptEntry)
-{
-    uint8_t activeIndex=ptEntry->activeIndex;
-    uint32_t srcAddress=ptEntry->Address[activeIndex&0x01];
-    uint32_t destAddress=ptEntry->Address[!(activeIndex&0x01)];
-    uint32_t destMaxSize= ptEntry->maxLen[!(activeIndex&0x01)];
-    uint32_t totalLen=ptEntry->len;
-    uint32_t dealLen=0;
-    uint32_t curLen=0;
-
-    if(SUCCESS!=XIP_SFlash_Erase_Need_Lock(&flashCfg,destAddress,destAddress+destMaxSize-1)){
-        MSG_ERR("Erase flash fail");
-        return BFLB_BOOT2_FLASH_ERASE_ERROR;
-    }
-
-    while(dealLen<totalLen){
-        curLen=totalLen-dealLen;
-        if(curLen>sizeof(boot2ReadBuf)){
-            curLen=sizeof(boot2ReadBuf);
-        }
-        if(BFLB_BOOT2_SUCCESS!=BLSP_MediaBoot_Read(srcAddress,boot2ReadBuf,curLen)){
-            MSG_ERR("Read FW fail when copy\r\n");
-            return BFLB_BOOT2_FLASH_READ_ERROR;
-        }
-        if(SUCCESS!=XIP_SFlash_Write_Need_Lock(&flashCfg,destAddress,boot2ReadBuf,curLen)){
-            MSG_ERR("Write flash fail");
-            return BFLB_BOOT2_FLASH_WRITE_ERROR;
-        }
-        srcAddress+=curLen;
-        destAddress+=curLen;
-        dealLen+=curLen;
-    }
-    return BFLB_BOOT2_SUCCESS;
-}
-
-/****************************************************************************//**
- * @brief  Boot2 deal with one firmware
- *
- * @param  activeID: Active partition table ID
- * @param  ptStuff: Pointer of partition table stuff
- * @param  ptEntry: Pointer of active entry
- * @param  fwName: Firmware name pointer
- * @param  type: Firmware name ID
- *
- * @return 0 for partition table changed,need re-parse,1 for partition table or entry parsed successfully
- *
-*******************************************************************************/
-static int BLSP_Boot2_Deal_One_FW(PtTable_ID_Type activeID,PtTable_Stuff_Config *ptStuff,
-                                    PtTable_Entry_Config *ptEntry,uint8_t *fwName,
-                                    PtTable_Entry_Type type)
-{
-    uint32_t ret;
-
-    if(fwName!=NULL){
-        MSG_DBG("Get FW:%s\r\n",fwName);
-        ret=PtTable_Get_Active_Entries_By_Name(ptStuff,fwName,ptEntry);
-    }else{
-        MSG_DBG("Get FW ID:%d\r\n",type);
-        ret=PtTable_Get_Active_Entries_By_ID(ptStuff,type,ptEntry);
-    }
-
-    if(PT_ERROR_SUCCESS!=ret){
-        MSG_ERR("Entry not found\r\n");
-    }else{
-        BLSP_Dump_PtEntry(ptEntry);
-        MSG_DBG("Check Img\r\n");
-        if(BLSP_Boot2_Check_XZ_FW(activeID,ptStuff,ptEntry)==1){
-            return 0;
-        }
-        /* Check if this partition need copy */
-        if(ptEntry->activeIndex>=2){
-            if(BFLB_BOOT2_SUCCESS==BLSP_Boot2_Do_FW_Copy(activeID,ptStuff,ptEntry)){
-                return 0;
-            }
-        }
-    }
-    return 1;
-}
-
-/****************************************************************************//**
- * @brief  Boot2 Roll back pt entry
- *
- * @param  activeID: Active partition table ID
- * @param  ptStuff: Pointer of partition table stuff
- * @param  ptEntry: Pointer of active entry
- *
- * @return Boot_Error_Code
- *
-*******************************************************************************/
-#ifdef BLSP_BOOT2_ROLLBACK
-static int32_t BLSP_Boot2_Rollback_PtEntry(PtTable_ID_Type activeID,PtTable_Stuff_Config *ptStuff,PtTable_Entry_Config *ptEntry)
-{
-    int32_t ret;
-
-    ptEntry->activeIndex=!(ptEntry->activeIndex&0x01);
-    ptEntry->age++;
-    ret=PtTable_Update_Entry((PtTable_ID_Type)(!activeID),ptStuff,ptEntry);
-    if(ret!=PT_ERROR_SUCCESS){
-        MSG_ERR("Update PT entry fail\r\n");
-        return BFLB_BOOT2_FAIL;
-    }
-    return BFLB_BOOT2_SUCCESS;
-}
 #endif
-
-/****************************************************************************//**
- * @brief  Boot2 get mfg start up request
- *
- * @param  activeID: Active partition table ID
- * @param  ptStuff: Pointer of partition table stuff
- * @param  ptEntry: Pointer of active entry
- *
- * @return 0 for partition table changed,need re-parse,1 for partition table or entry parsed successfully
- *
-*******************************************************************************/
-static void BLSP_Boot2_Get_MFG_StartReq(PtTable_ID_Type activeID,PtTable_Stuff_Config *ptStuff,PtTable_Entry_Config *ptEntry,uint8_t *userFwName)
-{
-    uint32_t ret;
-    uint32_t len=0;
-    uint8_t tmp[16+1]={0};
-
-    ret=PtTable_Get_Active_Entries_By_Name(ptStuff,(uint8_t*)"mfg",ptEntry);
-
-    if(PT_ERROR_SUCCESS==ret){
-        MSG_DBG("XIP_SFlash_Read_Need_Lock");
-        XIP_SFlash_Read_Need_Lock(&flashCfg,ptEntry->Address[0]+MFG_START_REQUEST_OFFSET,tmp,sizeof(tmp)-1);
-        MSG_DBG("%s",tmp);
-        if(tmp[0]=='0'||tmp[0]=='1'){
-            len=strlen((char*)tmp);
-            if(len<9){
-                ARCH_MemCpy_Fast(userFwName,tmp,len);
-                MSG_DBG("%s",tmp);
-            }
-        }
-    }else{
-        MSG_DBG("MFG not found");
-    }
-}
 
 /****************************************************************************//**
  * @brief  Boot2 get mfg start up request and return startup address
@@ -385,7 +208,6 @@ static void BLSP_Boot2_Get_MFG_StartReq(PtTable_ID_Type activeID,PtTable_Stuff_C
 static void BLSP_Boot2_Get_MFG_StartReq_By_Addr(PtTable_ID_Type activeID,PtTable_Stuff_Config *ptStuff,PtTable_Entry_Config *ptEntry,uint32_t *startAddr)
 {
     uint32_t ret;
-    uint32_t len=0;
     uint8_t tmp[16+1]={0};
 
     ret=PtTable_Get_Active_Entries_By_Name(ptStuff,(uint8_t*)"mfg",ptEntry);
@@ -418,19 +240,11 @@ static void BLSP_Boot2_Get_MFG_StartReq_By_Addr(PtTable_ID_Type activeID,PtTable
 *******************************************************************************/
 int main(void)
 {
-    uint32_t ret=0,i=0;
+    uint32_t ret=0;
     PtTable_Stuff_Config ptTableStuff[2];
     PtTable_ID_Type activeID;
     /* Init to zero incase only one cpu boot up*/
     PtTable_Entry_Config ptEntry[BFLB_BOOT2_CPU_MAX]={0};
-    uint32_t bootHeaderAddr[BFLB_BOOT2_CPU_MAX]={0};
-    uint8_t bootRollback[BFLB_BOOT2_CPU_MAX]={0};
-    uint8_t ptParsed=1;
-    uint8_t userFwName[9]={0};
-#ifdef BLSP_BOOT2_ROLLBACK
-    uint8_t rollBacked=0;
-#endif
-    uint8_t tempMode=0;
     Boot_Clk_Config clkCfg;
     uint8_t flashCfgBuf[4+sizeof(SPI_Flash_Cfg_Type)+4]={0};
 
@@ -498,7 +312,7 @@ int main(void)
     MSG("jump entry:%08x\r\n",(unsigned int)entry);
     BLSP_Boot2_Jump_Entry(entry);
 
-    return ;
+    return 0;
 }
 
 void bfl_main()

--- a/customer_app/sdk_app_dac/sdk_app_dac/main.c
+++ b/customer_app/sdk_app_dac/sdk_app_dac/main.c
@@ -132,8 +132,7 @@ static void cmd_play_audio(char *buf, int len, int argc, char **argv)
     int sampling = 0;
     int fd_audio;
     romfs_filebuf_t filebuf;
-    //uint16_t  *p_u16addr;
-    uint32_t *p_u32addr;
+    uint16_t  *p_u16addr;
     uint32_t bufsize;
     
     fd_audio = aos_open("/romfs/audio_32k", 0);
@@ -145,10 +144,12 @@ static void cmd_play_audio(char *buf, int len, int argc, char **argv)
     aos_ioctl(fd_audio, IOCTL_ROMFS_GET_FILEBUF, (long unsigned int)&filebuf);
     aos_close(fd_audio);
 
-    p_u32addr = filebuf.buf;
+    // From a long unsigned int* to a uint16_t* should be a NOP, even 
+    // considering alignment.
+    p_u16addr = (uint16_t*) filebuf.buf;
     bufsize = filebuf.bufsize;
     
-    audio_dac_dma_test(p_u32addr, bufsize, sampling); 
+    audio_dac_dma_test(p_u16addr, bufsize, sampling); 
 
     return;
 

--- a/customer_app/sdk_app_dac/sdk_app_dac/main.c
+++ b/customer_app/sdk_app_dac/sdk_app_dac/main.c
@@ -134,7 +134,7 @@ static void cmd_play_audio(char *buf, int len, int argc, char **argv)
     romfs_filebuf_t filebuf;
     uint16_t  *p_u16addr;
     uint32_t bufsize;
-    
+
     fd_audio = aos_open("/romfs/audio_32k", 0);
 
     if (fd_audio < 0) {
@@ -144,12 +144,12 @@ static void cmd_play_audio(char *buf, int len, int argc, char **argv)
     aos_ioctl(fd_audio, IOCTL_ROMFS_GET_FILEBUF, (long unsigned int)&filebuf);
     aos_close(fd_audio);
 
-    // From a long unsigned int* to a uint16_t* should be a NOP, even 
+    // From a long unsigned int* to a uint16_t* should be a NOP, even
     // considering alignment.
     p_u16addr = (uint16_t*) filebuf.buf;
     bufsize = filebuf.bufsize;
-    
-    audio_dac_dma_test(p_u16addr, bufsize, sampling); 
+
+    audio_dac_dma_test(p_u16addr, bufsize, sampling);
 
     return;
 
@@ -176,7 +176,7 @@ static void aos_loop_proc(void *pvParameters)
     if (0 == get_dts_addr("uart", &fdt, &offset)) {
         vfs_uart_init(fdt, offset);
     }
-     
+
     #ifdef CONF_USER_ENABLE_VFS_ROMFS
     romfs_register();
     printf("romfs register \r\n");
@@ -194,8 +194,8 @@ static void aos_loop_proc(void *pvParameters)
         aos_poll_read_fd(fd_console, aos_cli_event_cb_read_get(), (void*)0x12345678);
         _cli_init();
     }
-    
-    
+
+
     aos_loop_run();
 
     puts("------------------------------------------\r\n");


### PR DESCRIPTION
Don't cast - use the right type. The file's uint32_t alignment should be more restrictive than the
uint16_t alignment, so this SHOULD be safe ... and reduces build noise. 