### PR TITLE
More ppp backports

### DIFF
--- a/components/network/lwip/src/netif/ppp/eap.c
+++ b/components/network/lwip/src/netif/ppp/eap.c
@@ -1326,6 +1326,12 @@ static void eap_request(ppp_pcb *pcb, u_char *inp, int id, int len) {
 #endif /* USE_SRP */
 
 	/*
+	 * Ignore requests if we're not open
+	 */
+	if (esp->es_client.ea_state <= eapClosed)
+		return;
+
+	/*
 	 * Note: we update es_client.ea_id *only if* a Response
 	 * message is being generated.  Otherwise, we leave it the
 	 * same for duplicate detection purposes.
@@ -1737,6 +1743,12 @@ static void eap_response(ppp_pcb *pcb, u_char *inp, int id, int len) {
 	u_char dig[SHA_DIGESTSIZE];
 #endif /* USE_SRP */
 
+	/*
+	 * Ignore responses if we're not open
+	 */
+	if (esp->es_server.ea_state <= eapClosed)
+		return;
+
 	if (pcb->eap.es_server.ea_id != id) {
 		ppp_dbglog("EAP: discarding Response %d; expected ID %d", id,
 		    pcb->eap.es_server.ea_id);
@@ -2042,6 +2054,12 @@ static void eap_success(ppp_pcb *pcb, u_char *inp, int id, int len) {
  */
 static void eap_failure(ppp_pcb *pcb, u_char *inp, int id, int len) {
 	LWIP_UNUSED_ARG(id);
+
+	/*
+	 * Ignore responses if we're not open
+	 */
+	if (esp->es_client.ea_state <= eapClosed)
+		return;
 
 	if (!eap_client_active(pcb)) {
 		ppp_dbglog("EAP unexpected failure message in state %s (%d)",

--- a/components/network/lwip/src/netif/ppp/ipv6cp.c
+++ b/components/network/lwip/src/netif/ppp/ipv6cp.c
@@ -440,7 +440,7 @@ static void ipv6cp_init(ppp_pcb *pcb) {
     memset(ao, 0, sizeof(*ao));
 #endif /* 0 */
 
-    wo->accept_local = 1;
+    wo->accept_local = 0;
     wo->neg_ifaceid = 1;
     ao->neg_ifaceid = 1;
 
@@ -515,6 +515,7 @@ static void ipv6cp_resetci(fsm *f) {
     wo->req_ifaceid = wo->neg_ifaceid && ao->neg_ifaceid;
     
     if (!wo->opt_local) {
+	wo->accept_local = 1;
 	eui64_magic_nz(wo->ourid);
     }
     


### PR DESCRIPTION
Based on https://github.com/pine64/bl_iot_sdk/pull/21#issuecomment-718221832, I am adding two commits from [ppp repository](https://github.com/paulusmack/ppp). The first one (ignore received EAP messages when not doing EAP) was rebased as https://github.com/pine64/bl_iot_sdk/commit/6131dfddd8cfaf94ae694a03ec67e5cc16ebffb5#diff-2c9b83fa4781ad1823da18fd74f6f208631e4dd5f53e49934ebc2dcccb73c935R2056 is not present in pppd and I didn't try to compile it, it should be ok. The other one applies cleanly.