### PR TITLE
Fix mismatched datatypes in DMA arguments.

### DIFF
--- a/customer_app/sdk_app_dac/sdk_app_dac/main.c
+++ b/customer_app/sdk_app_dac/sdk_app_dac/main.c
@@ -132,7 +132,7 @@ static void cmd_play_audio(char *buf, int len, int argc, char **argv)
     int sampling = 0;
     int fd_audio;
     romfs_filebuf_t filebuf;
-    uint16_t  *p_u16addr;
+    uint16_t *p_u16addr;
     uint32_t bufsize;
     
     fd_audio = aos_open("/romfs/audio_32k", 0);

--- a/customer_app/sdk_app_dac/sdk_app_dac/main.c
+++ b/customer_app/sdk_app_dac/sdk_app_dac/main.c
@@ -132,8 +132,7 @@ static void cmd_play_audio(char *buf, int len, int argc, char **argv)
     int sampling = 0;
     int fd_audio;
     romfs_filebuf_t filebuf;
-    //uint16_t  *p_u16addr;
-    uint32_t *p_u32addr;
+    uint16_t  *p_u16addr;
     uint32_t bufsize;
     
     fd_audio = aos_open("/romfs/audio_32k", 0);
@@ -145,10 +144,12 @@ static void cmd_play_audio(char *buf, int len, int argc, char **argv)
     aos_ioctl(fd_audio, IOCTL_ROMFS_GET_FILEBUF, (long unsigned int)&filebuf);
     aos_close(fd_audio);
 
-    p_u32addr = filebuf.buf;
+    // From a long unsigned int* to a uint16_t* should be a NOP, even 
+    // considering alignment.
+    p_u16addr = (uint16_t*) filebuf.buf;
     bufsize = filebuf.bufsize;
     
-    audio_dac_dma_test(p_u32addr, bufsize, sampling); 
+    audio_dac_dma_test(p_u16addr, bufsize, sampling); 
 
     return;
 


### PR DESCRIPTION
The file's uint32_t alignment should be more restrictive than the
uint16_t alignment, so this SHOULD be safe ... and reduces build noise.
