### PR TITLE
Reverse sysctrl_init

### DIFF
--- a/make_scripts_riscv/project.mk
+++ b/make_scripts_riscv/project.mk
@@ -103,6 +103,7 @@ ifndef COMPONENT_DIRS
 EXTRA_COMPONENT_DIRS ?=
 COMPONENT_DIRS := $(PROJECT_PATH)/components $(EXTRA_COMPONENT_DIRS) $(BL60X_SDK_PATH)/components $(BL60X_SDK_PATH)/customer_components $(PROJECT_PATH)/$(PROJECT_NAME) $(PROJECT_COMPONENT)
 endif
+COMPONENT_DIRS += $(BL60X_SDK_PATH)/reversed
 export COMPONENT_DIRS
 
 # The project Makefile can define a list of components, but if it does not do this we just take all available components
@@ -123,6 +124,12 @@ COMPONENTS_REAL_PATH := $(patsubst %/,%,$(COMPONENTS_RAL_PATH))
 #endif
 # After a full manifest of component names is determined, subtract the ones explicitly omitted by the project Makefile.
 ifdef INCLUDE_COMPONENTS
+
+# If we use the proprietary bl602_wifi, add our REd part too
+ifneq ("$(filter bl602_wifi,$(INCLUDE_COMPONENTS))","")
+INCLUDE_COMPONENTS += bl602_wifi_re
+endif
+
 # match exclude comps with EXCLUDE_COMPONENTS variable
 define include_comps_add
 include_path += $(filter %/$(1), $(COMPONENTS_REAL_PATH))

--- a/reversed/bl602_wifi_re/bouffalo.mk
+++ b/reversed/bl602_wifi_re/bouffalo.mk
@@ -1,4 +1,4 @@
-COMPONENT_SRCS := ./sysctrl.c
+COMPONENT_SRCS := ./sysctrl.c ./hal_mib.c
 COMPONENT_OBJS := $(patsubst %.c,%.o, $(COMPONENT_SRCS))
 COMPONENT_SRCDIRS := ./
 

--- a/reversed/bl602_wifi_re/bouffalo.mk
+++ b/reversed/bl602_wifi_re/bouffalo.mk
@@ -1,0 +1,7 @@
+COMPONENT_SRCS := ./sysctrl.c
+COMPONENT_OBJS := $(patsubst %.c,%.o, $(COMPONENT_SRCS))
+COMPONENT_SRCDIRS := ./
+
+# make sure we overwrite the weak symbols in the proprietary lib
+COMPONENT_ADD_LDFLAGS_HEAD := -Wl,--whole-archive
+COMPONENT_ADD_LDFLAGS_TAIL := -Wl,--no-whole-archive

--- a/reversed/bl602_wifi_re/hal_mib.c
+++ b/reversed/bl602_wifi_re/hal_mib.c
@@ -1,0 +1,68 @@
+#include <stdint.h>
+#include <stdio.h>
+
+// from DWARF
+struct machw_mib_tag {
+    uint32_t dot11_wep_excluded_count;
+    uint32_t dot11_fcs_error_count;
+    uint32_t nx_rx_phy_error_count;
+    uint32_t nx_rd_fifo_overflow_count;
+    uint32_t nx_tx_underrun_count;
+    uint32_t reserved_1[7];
+    uint32_t nx_qos_utransmitted_mpdu_count[8];
+    uint32_t nx_qos_gtransmitted_mpdu_count[8];
+    uint32_t dot11_qos_failed_count[8];
+    uint32_t dot11_qos_retry_count[8];
+    uint32_t dot11_qos_rts_success_count[8];
+    uint32_t dot11_qos_rts_failure_count[8];
+    uint32_t nx_qos_ack_failure_count[8];
+    uint32_t nx_qos_ureceived_mpdu_count[8];
+    uint32_t nx_qos_greceived_mpdu_count[8];
+    uint32_t nx_qos_ureceived_other_mpdu[8];
+    uint32_t dot11_qos_retries_received_count[8];
+    uint32_t nx_utransmitted_amsdu_count[8];
+    uint32_t nx_gtransmitted_amsdu_count[8];
+    uint32_t dot11_failed_amsdu_count[8];
+    uint32_t dot11_retry_amsdu_count[8];
+    uint32_t dot11_transmitted_octets_in_amsdu[8];
+    uint32_t dot11_amsdu_ack_failure_count[8];
+    uint32_t nx_ureceived_amsdu_count[8];
+    uint32_t nx_greceived_amsdu_count[8];
+    uint32_t nx_ureceived_other_amsdu[8];
+    uint32_t dot11_received_octets_in_amsdu_count[8];
+    uint32_t reserved_2[24];
+    uint32_t dot11_transmitted_ampdu_count;
+    uint32_t dot11_transmitted_mpdus_in_ampdu_count;
+    uint32_t dot11_transmitted_octets_in_ampdu_count;
+    uint32_t wnlu_ampdu_received_count;
+    uint32_t nx_gampdu_received_count;
+    uint32_t nx_other_ampdu_received_count;
+    uint32_t dot11_mpdu_in_received_ampdu_count;
+    uint32_t dot11_received_octets_in_ampdu_count;
+    uint32_t dot11_ampdu_delimiter_crc_error_count;
+    uint32_t dot11_implicit_bar_failure_count;
+    uint32_t dot11_explicit_bar_failure_count;
+    uint32_t reserved_3[5];
+    uint32_t dot11_20mhz_frame_transmitted_count;
+    uint32_t dot11_40mhz_frame_transmitted_count;
+    uint32_t dot11_20mhz_frame_received_count;
+    uint32_t dot11_40mhz_frame_received_count;
+    uint32_t nx_failed_40mhz_txop;
+    uint32_t nx_successful_txops;
+    uint32_t reserved_4[4];
+    uint32_t dot11_dualcts_success_count;
+    uint32_t dot11_stbc_cts_success_count;
+    uint32_t dot11_stbc_cts_failure_count;
+    uint32_t dot11_non_stbc_cts_success_count;
+    uint32_t dot11_non_stbc_cts_failure_count;
+};
+
+static volatile struct machw_mib_tag *machw_mib = (struct machw_mib_tag *)0x44b00800;
+
+void hal_mib_dump(void) {
+  puts("---------- hal_mib_dump (re) ----------\r\n");
+  // notice the proprietary firmware chooses to only dump this one field - but presumably the
+  // hardware updates the others, too
+  printf("machw_mib nx_rd_fifo_overflow_count is %lu\r\n", machw_mib->nx_rd_fifo_overflow_count);
+  puts("\r\n");
+}

--- a/reversed/bl602_wifi_re/sysctrl.c
+++ b/reversed/bl602_wifi_re/sysctrl.c
@@ -1,0 +1,8 @@
+#include <stdint.h>
+
+void sysctrl_init(void) {
+    // sysctrl_diag_conf
+    *(uint32_t*)0x44900068 = 0x8000000c;
+    // sysctrl_misc_cntl
+    *(uint32_t*)0x449000e0 |= 0x1ff00;
+}


### PR DESCRIPTION
In the spirit of the original competition, add a reversed version of the proprietary sysctrl_init function.

But mostly, setup some infrastructure so it's possible to progressively replace proprietary symbols with reversed ones
and still build a working firmware.