### PR TITLE
Added .gitignore for build folders under customer_app

### DIFF
--- a/customer_app/benchmark_security_aes/.gitignore
+++ b/customer_app/benchmark_security_aes/.gitignore
@@ -1,0 +1,1 @@
+build_out

--- a/customer_app/bl602_boot2/.gitignore
+++ b/customer_app/bl602_boot2/.gitignore
@@ -1,0 +1,1 @@
+build_out

--- a/customer_app/bl602_boot2_mini/.gitignore
+++ b/customer_app/bl602_boot2_mini/.gitignore
@@ -1,0 +1,1 @@
+build_out

--- a/customer_app/bl602_demo_at/.gitignore
+++ b/customer_app/bl602_demo_at/.gitignore
@@ -1,0 +1,1 @@
+build_out

--- a/customer_app/bl602_demo_event/.gitignore
+++ b/customer_app/bl602_demo_event/.gitignore
@@ -1,0 +1,1 @@
+build_out

--- a/customer_app/bl602_demo_nano/.gitignore
+++ b/customer_app/bl602_demo_nano/.gitignore
@@ -1,0 +1,1 @@
+build_out

--- a/customer_app/bl602_demo_noconnectivity/.gitignore
+++ b/customer_app/bl602_demo_noconnectivity/.gitignore
@@ -1,0 +1,1 @@
+build_out

--- a/customer_app/bl602_demo_wifi/.gitignore
+++ b/customer_app/bl602_demo_wifi/.gitignore
@@ -1,0 +1,1 @@
+build_out

--- a/customer_app/sdk_app_audio_udp/.gitignore
+++ b/customer_app/sdk_app_audio_udp/.gitignore
@@ -1,0 +1,1 @@
+build_out

--- a/customer_app/sdk_app_ble_sync/.gitignore
+++ b/customer_app/sdk_app_ble_sync/.gitignore
@@ -1,0 +1,1 @@
+build_out

--- a/customer_app/sdk_app_blog/.gitignore
+++ b/customer_app/sdk_app_blog/.gitignore
@@ -1,0 +1,1 @@
+build_out

--- a/customer_app/sdk_app_cli/.gitignore
+++ b/customer_app/sdk_app_cli/.gitignore
@@ -1,0 +1,1 @@
+build_out

--- a/customer_app/sdk_app_cronalarm/.gitignore
+++ b/customer_app/sdk_app_cronalarm/.gitignore
@@ -1,0 +1,1 @@
+build_out

--- a/customer_app/sdk_app_dac/.gitignore
+++ b/customer_app/sdk_app_dac/.gitignore
@@ -1,0 +1,1 @@
+build_out

--- a/customer_app/sdk_app_easyflash/.gitignore
+++ b/customer_app/sdk_app_easyflash/.gitignore
@@ -1,0 +1,1 @@
+build_out

--- a/customer_app/sdk_app_event/.gitignore
+++ b/customer_app/sdk_app_event/.gitignore
@@ -1,0 +1,1 @@
+build_out

--- a/customer_app/sdk_app_fdt/.gitignore
+++ b/customer_app/sdk_app_fdt/.gitignore
@@ -1,0 +1,1 @@
+build_out

--- a/customer_app/sdk_app_gpio/.gitignore
+++ b/customer_app/sdk_app_gpio/.gitignore
@@ -1,0 +1,1 @@
+build_out

--- a/customer_app/sdk_app_hbnram/.gitignore
+++ b/customer_app/sdk_app_hbnram/.gitignore
@@ -1,0 +1,1 @@
+build_out

--- a/customer_app/sdk_app_heap/.gitignore
+++ b/customer_app/sdk_app_heap/.gitignore
@@ -1,0 +1,1 @@
+build_out

--- a/customer_app/sdk_app_helloworld/.gitignore
+++ b/customer_app/sdk_app_helloworld/.gitignore
@@ -1,0 +1,1 @@
+build_out

--- a/customer_app/sdk_app_http_client_socket/.gitignore
+++ b/customer_app/sdk_app_http_client_socket/.gitignore
@@ -1,0 +1,1 @@
+build_out

--- a/customer_app/sdk_app_http_client_tcp/.gitignore
+++ b/customer_app/sdk_app_http_client_tcp/.gitignore
@@ -1,0 +1,1 @@
+build_out

--- a/customer_app/sdk_app_i2c/.gitignore
+++ b/customer_app/sdk_app_i2c/.gitignore
@@ -1,0 +1,1 @@
+build_out

--- a/customer_app/sdk_app_ir/.gitignore
+++ b/customer_app/sdk_app_ir/.gitignore
@@ -1,0 +1,1 @@
+build_out

--- a/customer_app/sdk_app_mdns/.gitignore
+++ b/customer_app/sdk_app_mdns/.gitignore
@@ -1,0 +1,1 @@
+build_out

--- a/customer_app/sdk_app_pwm/.gitignore
+++ b/customer_app/sdk_app_pwm/.gitignore
@@ -1,0 +1,1 @@
+build_out

--- a/customer_app/sdk_app_romfs/.gitignore
+++ b/customer_app/sdk_app_romfs/.gitignore
@@ -1,0 +1,1 @@
+build_out

--- a/customer_app/sdk_app_timer/.gitignore
+++ b/customer_app/sdk_app_timer/.gitignore
@@ -1,0 +1,1 @@
+build_out

--- a/customer_app/sdk_app_uart_ctl/.gitignore
+++ b/customer_app/sdk_app_uart_ctl/.gitignore
@@ -1,0 +1,1 @@
+build_out

--- a/customer_app/sdk_app_uart_echo/.gitignore
+++ b/customer_app/sdk_app_uart_echo/.gitignore
@@ -1,0 +1,1 @@
+build_out


### PR DESCRIPTION
I had to come up with a small one-liner in bash in order to do this, I'm leaving this here for future reference;

```
for i in $(ls); do; touch $i/.gitignore; (echo build_out > $i/.gitignore); done;
```

I believe that this small change will make development significantly less frustrating. All of the Makefile files inherit from `include $(BL60X_SDK_PATH)/make_scripts_riscv/project.mk`, so although I only tested whether the output directory was the same for `bl602_boot2`, `bl602_boot2_mini`, `bl602_demo_at` and `bl602_demo_event` (as well as `sdk_app_helloworld`, just to be sure), the output folder should always be `build_out` for every app under `customer_app`.