### PR TITLE
ci: gitignore backup files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 
 # MacOS
 .DS_Store
+
+# Emacs and mv -b backups
+*~


### PR DESCRIPTION
created by emacs and e.g. mv -b