### PR TITLE
Initialisation Fixes

### DIFF
--- a/components/network/ble/blestack/src/host/gatt.c
+++ b/components/network/ble/blestack/src/host/gatt.c
@@ -1964,7 +1964,7 @@ int bt_gatt_indicate(struct bt_conn *conn,
 {
 	struct notify_data data;
 	const struct bt_gatt_attr *attr;
-	u16_t handle;
+	u16_t handle = 0;
 
 	__ASSERT(params, "invalid parameters\n");
 	__ASSERT(params->attr, "invalid parameters\n");

--- a/components/network/ble/blestack/src/host/gatt.c
+++ b/components/network/ble/blestack/src/host/gatt.c
@@ -1900,7 +1900,7 @@ int bt_gatt_notify_cb(struct bt_conn *conn,
 {
 	struct notify_data data;
 	const struct bt_gatt_attr *attr;
-	u16_t handle;
+	u16_t handle = 0;
 
 	__ASSERT(params, "invalid parameters\n");
 	__ASSERT(params->attr, "invalid parameters\n");

--- a/components/network/lwip/src/core/raw.c
+++ b/components/network/lwip/src/core/raw.c
@@ -141,6 +141,10 @@ raw_input(struct pbuf *p, struct netif *inp)
 
   LWIP_UNUSED_ARG(inp);
 
+#if !(LWIP_IPV4) && !(LWIP_IPV6)
+#error proto not initialised, please set either LWIP_IPV4 and/or LWIP_IPV6
+#endif
+
 #if LWIP_IPV6
 #if LWIP_IPV4
   if (IP_HDR_GET_VERSION(p->payload) == 6)

--- a/components/security/mbedtls/src/ecjpake.c
+++ b/components/security/mbedtls/src/ecjpake.c
@@ -102,7 +102,7 @@ int mbedtls_ecjpake_setup( mbedtls_ecjpake_context *ctx,
                            const unsigned char *secret,
                            size_t len )
 {
-    int ret;
+    int ret = 0;
 
     ctx->role = role;
 

--- a/components/security/mbedtls/src/ssl_cli.c
+++ b/components/security/mbedtls/src/ssl_cli.c
@@ -2726,7 +2726,7 @@ static int ssl_parse_server_hello_done( mbedtls_ssl_context *ssl )
 static int ssl_write_client_key_exchange( mbedtls_ssl_context *ssl )
 {
     int ret;
-    size_t i, n;
+    size_t i = 0, n = 0;
     const mbedtls_ssl_ciphersuite_t *ciphersuite_info = ssl->transform_negotiate->ciphersuite_info;
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> write client key exchange" ) );

--- a/components/security/mbedtls/src/ssl_cli.c
+++ b/components/security/mbedtls/src/ssl_cli.c
@@ -2339,7 +2339,7 @@ static int ssl_parse_server_key_exchange( mbedtls_ssl_context *ssl )
         ciphersuite_info->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_RSA ||
         ciphersuite_info->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA )
     {
-        size_t sig_len, hashlen;
+        size_t sig_len, hashlen = 0;
         unsigned char hash[64];
         mbedtls_md_type_t md_alg = MBEDTLS_MD_NONE;
         mbedtls_pk_type_t pk_alg = MBEDTLS_PK_NONE;

--- a/components/security/mbedtls/src/ssl_tls.c
+++ b/components/security/mbedtls/src/ssl_tls.c
@@ -488,8 +488,8 @@ int mbedtls_ssl_derive_keys( mbedtls_ssl_context *ssl )
     unsigned char keyblk[256];
     unsigned char *key1;
     unsigned char *key2;
-    unsigned char *mac_enc;
-    unsigned char *mac_dec;
+    unsigned char *mac_enc = NULL;
+    unsigned char *mac_dec = NULL;
     size_t iv_copy_len;
     const mbedtls_cipher_info_t *cipher_info;
     const mbedtls_md_info_t *md_info;
@@ -817,7 +817,9 @@ int mbedtls_ssl_derive_keys( mbedtls_ssl_context *ssl )
 #if defined(MBEDTLS_SSL_PROTO_SSL3)
     if( ssl->minor_ver == MBEDTLS_SSL_MINOR_VERSION_0 )
     {
-        if( transform->maclen > sizeof transform->mac_enc )
+        if( transform->maclen > sizeof transform->mac_enc ||
+            mac_enc == NULL                               ||
+            mac_dec == NULL )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "should never happen" ) );
             return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );


### PR DESCRIPTION
Some fixes around possible uninitialized variables that could lead to undesired behaviour. They are unlikely to be seen in the wild as they would mostly require misconfiguration.

I've tried to make sure they are initialized to sane defaults and throw a compiler error where that's not really possible (neither IPv4 or IPv6 set).