### PR TITLE
Fix make on darwin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 
 # MacOS
 .DS_Store
+__pycache__

--- a/image_conf/requirements.txt
+++ b/image_conf/requirements.txt
@@ -1,3 +1,5 @@
 # flash_build.py dependencies
 fdt>=0.2.0
 pycryptodomex>=3.9.8
+toml>=0.10.2
+configobj>=5.0.6

--- a/make_scripts_riscv/project.mk
+++ b/make_scripts_riscv/project.mk
@@ -187,8 +187,8 @@ all:
 ifeq ("$(OS)","Windows_NT")
 else
 ifeq ("$(CONFIG_CHIP_NAME)", "BL602")
-	#@cd $(BL60X_SDK_PATH)/image_conf; python3 flash_build.py $(PROJECT_NAME) $(CONFIG_CHIP_NAME)
-	@cd $(BL60X_SDK_PATH)/image_conf; ./flash_build $(PROJECT_NAME) $(CONFIG_CHIP_NAME)
+	@cd $(BL60X_SDK_PATH)/image_conf;python3 -m pip install -r requirements.txt; python3 flash_build.py $(PROJECT_NAME) $(CONFIG_CHIP_NAME)
+	#@cd $(BL60X_SDK_PATH)/image_conf; ./flash_build $(PROJECT_NAME) $(CONFIG_CHIP_NAME)
 endif
 endif
 	@echo "Building Finish. To flash build output."


### PR DESCRIPTION
When I run make on Darwin(macos 10.15), make fails because the make script is trying to execute a linux elf binary.

```
/bin/sh: ./flash_build: cannot execute binary file
make: *** [all] Error 126
```

Since it looks like the `flash_build.py` doing the same thing, I switched that line to install the python script dependencies and execute it. I also fixed `requirements.txt` to include all the dependencies `toml` and `configobj` were missing.
