### PR TITLE
Purge "invisible" and incorrect tabs from Makefiles in make_scripts_scripts

### DIFF
--- a/make_scripts_riscv/project.mk
+++ b/make_scripts_riscv/project.mk
@@ -188,7 +188,7 @@ ifeq ("$(OS)","Windows_NT")
 else
 ifeq ("$(CONFIG_CHIP_NAME)", "BL602")
 	@cd $(BL60X_SDK_PATH)/image_conf;python3 -m pip install -r requirements.txt; python3 flash_build.py $(PROJECT_NAME) $(CONFIG_CHIP_NAME)
-	#@cd $(BL60X_SDK_PATH)/image_conf; ./flash_build $(PROJECT_NAME) $(CONFIG_CHIP_NAME)
+#@cd $(BL60X_SDK_PATH)/image_conf; ./flash_build $(PROJECT_NAME) $(CONFIG_CHIP_NAME)
 endif
 endif
 	@echo "Building Finish. To flash build output."
@@ -291,7 +291,6 @@ COMMON_FLAGS_M4_EXT := 	\
 	-ffreestanding \
 	-fno-strict-aliasing
 
-		
 COMMON_FLAGS += $(COMMON_FLAGS_M4_EXT)
 
 ifdef CONFIG_STACK_CHECK_NORM
@@ -454,7 +453,6 @@ else
 endif
 endif
 endif
-	
 
 $(BUILD_DIR_BASE):
 	mkdir -p $(BUILD_DIR_BASE)


### PR DESCRIPTION
Purge "invisible" and incorrect tabs from Makefiles in make_scripts_scripts/.

Note: For `"<tab># comment"`, `"# comment"` is a command and passed to the shell. Most shells interpret` "# comment"` as a comment - thankfully. A comment is `"# comment`", only.