### PR TITLE
removed crazy characters so dts to dtb wouldnt fail

### DIFF
--- a/tools/flash_tool/bl602/device_tree/bl_factory_params_IoTKitA_40M.dts
+++ b/tools/flash_tool/bl602/device_tree/bl_factory_params_IoTKitA_40M.dts
@@ -177,15 +177,15 @@
         tx {
             status = "disable";
             pin = <11>;         // only support 11
-            mode = "NEC";       // NEC、ExtenedNEC、RC5、SWM
+            mode = "NEC";       // NECExtenedNECRC5SWM
             interval = <100>;   // ms
-            active_mode = "Hi"; //Hi、Lo
+            active_mode = "Hi"; //HiLo
         };
         rx {
             status = "okay";
             pin = <12>;         // only support 12 13
-            mode = "NEC";       // NEC、ExtenedNEC、RC5、SWM
-            active_mode = "Hi"; //Hi、Lo
+            mode = "NEC";       // NECExtenedNECRC5SWM
+            active_mode = "Hi"; //HiLo
         };
     };
     uart {


### PR DESCRIPTION
There was the character 
```
、
```
in a bunch of comments inside of `bl_iot_sdk/tools/flash_tool/bl602/device_tree/bl_factory_params_IoTKitA_40M.dts` that was causing the dts -> dtb to fail inside of BLDevCube. I removed those and now it works.