### PR TITLE
Fix CI ignoring build errors

### DIFF
--- a/customer_app/Makefile
+++ b/customer_app/Makefile
@@ -1,6 +1,12 @@
-.PHONY: app
+.PHONY: app clean
 
-app:
-	find . -maxdepth 2 -mindepth 2 -type d -execdir ./genromap {} \;
+DIRECTORIES := $(wildcard */)
+
+app: $(DIRECTORIES)
+
+$(DIRECTORIES)::
+	echo building $@...
+	cd $@ && ./genromap
+
 clean:
-	find . -name build_out|xargs rm -rf
+	find . -name build_out | xargs rm -rf


### PR DESCRIPTION
The  customer_app/Makefile returns success status even if one of the build scripts failed.
Since CI (https://github.com/pine64/bl_iot_sdk/pull/68) uses it it always succeeds even if there were errors during compilation.