### PR TITLE
Add basic debian-based dockerfile to test building

### DIFF
--- a/Dockerfile.bundled
+++ b/Dockerfile.bundled
@@ -2,7 +2,7 @@ FROM debian:buster
 
 RUN set -eux \
     && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get upgrade;apt-get update \
+    && apt-get update;apt-get upgrade \
     && apt install -y build-essential python3 python3-pip \
     && apt-get -y --purge autoremove \
     && apt-get clean \

--- a/Dockerfile.bundled
+++ b/Dockerfile.bundled
@@ -1,0 +1,16 @@
+FROM debian:buster
+
+RUN set -eux \
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get upgrade;apt-get update \
+    && apt install -y build-essential python3 python3-pip \
+    && apt-get -y --purge autoremove \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+    
+    
+RUN pip3 install fdt
+
+COPY . /src
+WORKDIR /src
+ENTRYPOINT /bin/bash

--- a/README.rst
+++ b/README.rst
@@ -61,6 +61,15 @@ you will need to define a few variables in order to compile it::
    export BL60X_SDK_PATH=/path/to/this/repo
    export CONFIG_CHIP_NAME=bl602 
 
+Docker
+====
+
+To set up a development environment in Docker, and do a full build of all the example projects, using the bundled toolchain::
+
+    docker build -t bl602sdk -f Dockerfile.bundled
+    docker run -t -i --rm bl602sdk
+    # make
+
 Hardware
 --------
 BL602 is a 32-bit RISC-V based combo chipset supporting Wi-Fi and BLE (Bluetooth


### PR DESCRIPTION
Adds a basic debian buster docker image, and installs the basic packages required to enable a quick "build-test" of all the example projects. This might be helpful for automated testing of toolchains at some point, or the sample code, or for those who can't get the setup to work on their normal install, and want to try a "known-good" setup.