### PR TITLE
Remove pyinstaller-packed binary version of flash_build.py

### DIFF
--- a/make_scripts_riscv/project.mk
+++ b/make_scripts_riscv/project.mk
@@ -188,7 +188,6 @@ ifeq ("$(OS)","Windows_NT")
 else
 ifeq ("$(CONFIG_CHIP_NAME)", "BL602")
 	@cd $(BL60X_SDK_PATH)/image_conf;python3 -m pip install -r requirements.txt; python3 flash_build.py $(PROJECT_NAME) $(CONFIG_CHIP_NAME)
-#@cd $(BL60X_SDK_PATH)/image_conf; ./flash_build $(PROJECT_NAME) $(CONFIG_CHIP_NAME)
 endif
 endif
 	@echo "Building Finish. To flash build output."


### PR DESCRIPTION
No scripts actually use this version: the one reference to it, which I've also removed in this commit, was commented out. Having the binary version is confusing because it indicates a proprietary component where there is none. It's also of limited use, since it only works on 64-bit Linux (and, at least on my system, doesn't even run properly there).

I disassembled the bytecode of the compiled version and the source version and verified that they are identical, so we are losing nothing with this deletion.

**Binary version disassembly**: [flash_build_binary_disassembly.txt](https://github.com/pine64/bl_iot_sdk/files/5756014/flash_build_binary_disassembly.txt)
**Source version disassembly**: [flash_build_source_disassembly.txt](https://github.com/pine64/bl_iot_sdk/files/5756012/flash_build_source_disassembly.txt) (removed the shebang added by 74e20e247129b4b22bdc8917c43d87dd6acc4e6e to make the line numbers match)

As you can see, they differ only in internal addresses of the disassembled objects.