### PR TITLE
fix build error

### DIFF
--- a/image_conf/flash_build.py
+++ b/image_conf/flash_build.py
@@ -33,7 +33,7 @@ dict_xtal = {"24M": 1, "32M": "2", "38.4M": "3", "40M": "4", "26M": "5", "RC32M"
 
 def bl_find_file_list(key_val, endswith):
     file_path_list = []
-    conf_path = os.path.join(app_path, "img_conf")
+    conf_path = os.path.join(search_path, "img_conf")
     if os.path.exists(conf_path):
         files = os.listdir(conf_path)
         for f in files:
@@ -54,7 +54,7 @@ def bl_find_file_list(key_val, endswith):
 
 
 def bl_find_file(key_val, endswith):
-    conf_path = os.path.join(app_path, "img_conf")
+    conf_path = os.path.join(search_path, "img_conf")
     if os.path.exists(conf_path):
         files = os.listdir(conf_path)
         for f in files:
@@ -1388,7 +1388,8 @@ class bl_flash_select():
 
 if __name__ == '__main__':
     abs_path = os.path.abspath('..')
-    app_path = os.path.join(abs_path, "customer_app", sys.argv[1])
+    search_path = os.path.join(abs_path, "customer_app", sys.argv[1])
+    app_path = sys.argv[3] # path to the build location
     demo_name = sys.argv[1]
     chip_name = sys.argv[2].lower()
     default_conf_path = chip_name

--- a/make_scripts_riscv/project.mk
+++ b/make_scripts_riscv/project.mk
@@ -192,7 +192,7 @@ ifeq ("$(OS)","Windows_NT")
 else
 ifeq ("$(CONFIG_CHIP_NAME)", "BL602")
 	@env -u CC -u CXX -u AR -u CFLAGS -u CPPFLAGS python3 -m pip install -r $(BL60X_SDK_PATH)/image_conf/requirements.txt
-	@cd $(BL60X_SDK_PATH)/image_conf && python3 flash_build.py $(PROJECT_NAME) $(CONFIG_CHIP_NAME)
+	@cd $(BL60X_SDK_PATH)/image_conf && python3 flash_build.py $(PROJECT_NAME) $(CONFIG_CHIP_NAME) $(PROJECT_PATH)
 endif
 endif
 	@echo "Building Finish. To flash build output."


### PR DESCRIPTION
Fix an error that happens if the build is made out of the SDK's `customer_app` folder.
The error doesn't prevent the build of the binary though.
This is the error that the fix now avoids: 
```
Traceback (most recent call last):
  File "<path_to_sdk>/bl_iot_sdk/image_conf/flash_build.py", line 1397, in <module>
    shutil.copy(eflash_loader_cfg_org, eflash_loader_cfg)
  File "/usr/lib/python3.9/shutil.py", line 418, in copy
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "/usr/lib/python3.9/shutil.py", line 264, in copyfile
    with open(src, 'rb') as fsrc, open(dst, 'wb') as fdst:
FileNotFoundError: [Errno 2] No such file or directory: '<path_to_sdk>/bl_iot_sdk/customer_app/project/build_out/eflash_loader_cfg.ini'
make: *** [<path_to_sdk>/bl_iot_sdk/make_scripts_riscv/project.mk:195: all] Error 1
```